### PR TITLE
Add cppcheck and clang-format check to github actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,8 +38,7 @@ jobs:
           std: c++14
           exclude_check: ./build
           
-    - name: cppcheck - report
-      if: always()    
+    - name: cppcheck - report  
       run: if [ -f "./cppcheck_report.txt" ];  then cat ./cppcheck_report.txt && (exit 1); else (exit 0); fi 
 
     - name: Clang-format - report 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,8 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    
+    - name: checkout 
+      uses: actions/checkout@v2
+           
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
@@ -29,18 +30,15 @@ jobs:
     - name: Tests
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{env.BUILD_TYPE}}
-
-    - name: cppcheck - prepearing
-      uses: deep5050/cppcheck-action@main
-      with:
-          github_token: ${{ secrets.GITHUB_TOKEN}}
-          std: c++14
-          exclude_check: ./build
           
+    - name: cppcheck - prepearing
+      run:  sudo apt-get -qq -y install curl cmake jq clang cppcheck &&  cppcheck --enable=all --inconclusive -i./build --std=c++14 --output-file=cppcheck_report.txt .
+                 
     - name: cppcheck - report  
       run: if [ -f "./cppcheck_report.txt" ];  then cat ./cppcheck_report.txt && (exit 1); else (exit 0); fi 
 
-    - name: Clang-format - report  
+    - name: Clang-format - report
+      if: always()
       uses: DoozyX/clang-format-lint-action@v0.13
       with:
         source: '.'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
       run:  sudo apt-get -qq -y install curl cmake jq clang cppcheck &&  cppcheck --enable=all --inconclusive -i./build --std=c++14 --output-file=cppcheck_report.txt --suppress=missingIncludeSystem .
                  
     - name: cppcheck - report  
-      run: if [ -f "./cppcheck_report.txt" ];  then cat ./cppcheck_report.txt && (exit 1); else (exit 0); fi 
+      run: if [ -s "./cppcheck_report.txt" ];  then cat ./cppcheck_report.txt && (exit 1); else (exit 0); fi 
 
     - name: Clang-format - report
       if: always()

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,6 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}}
 
     - name: cppcheck - prepearing
-      if: always()
       uses: deep5050/cppcheck-action@main
       with:
           github_token: ${{ secrets.GITHUB_TOKEN}}
@@ -41,8 +40,7 @@ jobs:
     - name: cppcheck - report  
       run: if [ -f "./cppcheck_report.txt" ];  then cat ./cppcheck_report.txt && (exit 1); else (exit 0); fi 
 
-    - name: Clang-format - report 
-      if: always()    
+    - name: Clang-format - report  
       uses: DoozyX/clang-format-lint-action@v0.13
       with:
         source: '.'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,19 +19,34 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
-      # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
+    - name: Tests
       working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-      
+
+    - name: cppcheck - prepearing
+      if: always()
+      uses: deep5050/cppcheck-action@main
+      with:
+          github_token: ${{ secrets.GITHUB_TOKEN}}
+          std: c++14
+          exclude_check: ./build
+          
+    - name: cppcheck - report
+      if: always()    
+      run: if [ -f "./cppcheck_report.txt" ];  then cat ./cppcheck_report.txt && (exit 1); else (exit 0); fi 
+
+    - name: Clang-format - report 
+      if: always()    
+      uses: DoozyX/clang-format-lint-action@v0.13
+      with:
+        source: '.'
+        exclude: './build'
+        extensions: 'h,cpp'
+        style: Google

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}}
           
     - name: cppcheck - prepearing
-      run:  sudo apt-get -qq -y install curl cmake jq clang cppcheck &&  cppcheck --enable=all --inconclusive -i./build --std=c++14 --output-file=cppcheck_report.txt .
+      run:  sudo apt-get -qq -y install curl cmake jq clang cppcheck &&  cppcheck --enable=all --inconclusive -i./build --std=c++14 --output-file=cppcheck_report.txt --suppress=missingIncludeSystem .
                  
     - name: cppcheck - report  
       run: if [ -f "./cppcheck_report.txt" ];  then cat ./cppcheck_report.txt && (exit 1); else (exit 0); fi 


### PR DESCRIPTION
Added two additional items to github actions: cppcheck and clang-format checks 
![image](https://user-images.githubusercontent.com/9269521/152046590-e7f7eedf-5b47-4d08-96fb-cf3bfa9123dc.png)

Example of output of cppcheck: 
![image](https://user-images.githubusercontent.com/9269521/152046876-c556cf82-a86e-4cb2-8c97-2c268ca2a932.png)

Example of output clang-format:
![image](https://user-images.githubusercontent.com/9269521/152047002-a9b8964e-c677-47cf-addb-eab838b7946a.png)
