### PR TITLE
init logger commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.11)
 include_directories(include)
 
 add_executable(main 
+              src/logger.cpp
               src/main.cpp 
               src/yaml_parse.cpp
               src/process_start.cpp)	
@@ -36,3 +37,4 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(tests)
+

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,0 +1,35 @@
+#ifndef _LOGGER
+#define _LOGGER
+
+#include <fstream>
+#include <iostream>
+
+// todo : add mutex , add log-level
+
+enum typelog { DEBUG, INFO, WARN, ERROR };
+
+class Logger {
+ public:
+  static Logger *getInstance() {
+    static Logger instance;
+    return &instance;
+  }
+
+  void test();
+
+  void set_log_path(std::string path) {
+    out.close();
+    log_path = path;
+  }
+
+  void log(std::string text, typelog tp = WARN);
+
+ private:
+  std::ofstream out;
+  std::string log_path = "log.log";
+  inline std::string getLabel(typelog type);
+  Logger() {}
+};
+
+void LOG(std::string s, typelog tp);
+#endif

--- a/include/logger.h
+++ b/include/logger.h
@@ -22,7 +22,7 @@ class Logger {
     log_path = path;
   }
 
-  void log(std::string text, typelog tp = WARN);
+  void log(const std::string &text, typelog tp = WARN);
 
  private:
   std::ofstream out;
@@ -31,5 +31,5 @@ class Logger {
   Logger() {}
 };
 
-void LOG(std::string s, typelog tp);
+void LOG(const std::string &s, typelog tp);
 #endif

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -4,7 +4,7 @@
 #include <iomanip>
 #include <iostream>
 
-void Logger::log(std::string text, typelog type) {
+void Logger::log(const std::string &text, typelog type) {
   if (!out.is_open()) {
     out.open(log_path, std::ios_base::app);
   }
@@ -37,6 +37,6 @@ inline std::string Logger::getLabel(typelog type) {
   return label;
 }
 
-void LOG(std::string s, typelog tp) {  // alias
+void LOG(const std::string &s, typelog tp) {  // alias
   Logger::getInstance()->log(s, tp);
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,42 @@
+#include "logger.h"
+
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+
+void Logger::log(std::string text, typelog type) {
+  if (!out.is_open()) {
+    out.open(log_path, std::ios_base::app);
+  }
+
+  if (out.is_open()) {
+    auto t = std::time(nullptr);
+    auto tm = *std::localtime(&t);
+
+    out << std::put_time(&tm, "%d-%m-%Y %H-%M-%S")
+        << (" [" + getLabel(type) + "] ") << text << std::endl;
+  }
+}
+
+inline std::string Logger::getLabel(typelog type) {
+  std::string label;
+  switch (type) {
+    case DEBUG:
+      label = "DEBUG";
+      break;
+    case INFO:
+      label = "INFO ";
+      break;
+    case WARN:
+      label = "WARN ";
+      break;
+    case ERROR:
+      label = "ERROR";
+      break;
+  }
+  return label;
+}
+
+void LOG(std::string s, typelog tp) {  // alias
+  Logger::getInstance()->log(s, tp);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,15 @@
 #include <iostream>
 
+#include "logger.h"
 #include "process_start.h"
 #include "yaml_parse.h"
 
 using namespace std;
 
 int main(int argc, char *argv[]) {
+  Logger::getInstance()->set_log_path("custom.log");
+  LOG("Started", INFO);
+
   if (argc > 1) {
     try {
       auto program = parse_yaml(argv[1]);
@@ -19,11 +23,13 @@ int main(int argc, char *argv[]) {
       // wait until processes are done
       wait(nullptr);
     } catch (std::exception &ex) {
+      LOG(std::string("Ouch! That hurts, because: ") + ex.what(), ERROR);
       cout << "Ouch! That hurts, because: " << ex.what() << "!" << endl;
     }
   } else {
+    LOG("Cant find config file: ", ERROR);
     cout << "Pass config filename as first argument to program" << endl;
   }
-
+  LOG("Finished", INFO);
   return 0;
 }

--- a/src/yaml_parse.cpp
+++ b/src/yaml_parse.cpp
@@ -5,6 +5,8 @@
 #include <map>
 #include <vector>
 
+#include "logger.h"
+
 using namespace std;
 
 std::vector<set_prog_start> parse_yaml(const std::string &filename) {
@@ -14,6 +16,7 @@ std::vector<set_prog_start> parse_yaml(const std::string &filename) {
   ifstream file(filename);
 
   if (!file) {
+    LOG("Could not open config file " + filename, ERROR);
     throw std::runtime_error("Could not open config file " + filename);
   }
   set_prog_start config_buffer;
@@ -21,6 +24,7 @@ std::vector<set_prog_start> parse_yaml(const std::string &filename) {
     if (line.find("  - name: ") == 0) {
       if (config_buffer.name != "" and config_buffer.executable_path != "") {
         out.push_back(config_buffer);
+        LOG("Parsed from config file: " + config_buffer.name, INFO);
       }
       config_buffer = {};
       config_buffer.stdout_config_truncate = true;

--- a/tests/unit/yaml_parse_test.cpp
+++ b/tests/unit/yaml_parse_test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "../../src/logger.cpp"
+
 TEST(yaml_parce_test, BasicAssertions) {
   std::vector<set_prog_start> parced = parse_yaml("../tests/example_1.yml");
 


### PR DESCRIPTION
Logger singleton added

for using 
1) add `#include "logger.h"` to your unit
2) `LOG("message", ERROR);`  where "message" is std::string and ERROR are enum DEBUG/INFO/WARN/ERROR

Example in main.cpp and yaml_parse.cpp


For change logfile path, use 
  `Logger::getInstance()->set_log_path("custom.log");`


Not tested with forked process yet.
