### PR TITLE
Fix no return of non-void function

### DIFF
--- a/src/process_start.cpp
+++ b/src/process_start.cpp
@@ -12,6 +12,7 @@ pid_t start_process(set_prog_start &program) {
         "program_name: " +
             program.name,
         ERROR);
+    return 0;
   } else if (process_pid != 0) {
     // parent process
     // return child pid


### PR DESCRIPTION
Small fix to process_start_function, when we couldn't fork(), we need to leave function with RETURN 0.